### PR TITLE
Fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,18 @@
 pes_parent_dir:=$(shell pwd)/$(lastword $(MAKEFILE_LIST))
 cur_makefile_path := $(shell dirname $(pes_parent_dir))
 
-all: build build-example target/tikv-example
+all: build target/tikv-example
 
 build: pre-build target/debug/libtikv_client.a
 
 release: pre-build target/release/libtikv_client.a
 
-pre-build: target/tikv_client_glue.cc include/tikv_client_glue.h
-	mkdir target
+.PHONY: directories
+
+directories:
+	mkdir -p target
+
+pre-build: directories target/tikv_client_glue.cc include/tikv_client_glue.h
 
 clean:
 	cargo clean

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This client is still in the stage of prove-of-concept and under heavy developmen
 ## Build
 
 ```bash
+# cxxbridge-cmd 1.0.18 requires rustc 1.48+ and c++11 or newer
 cargo install cxxbridge-cmd --force --version 1.0.18
 make
 ```


### PR DESCRIPTION
I ran `make` and got these error:

```
>  make
cxxbridge /data3/my/client-cpp/src/lib.rs > /data3/my/client-cpp/target/tikv_client_glue.cc
/bin/sh: /data3/my/client-cpp/target/tikv_client_glue.cc: No such file or directory
make: *** [target/tikv_client_glue.cc] Error 1
```

This PR fix the Makefile to make directory "target" before building `target/tikv_client_glue.cc`