### PR TITLE
Improve error handling to distinguishes errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ run-example: target/tikv-example
 	RUST_LOG=debug $(cur_makefile_path)/target/tikv-example
 
 target/tikv-example: target/debug/libtikv_client.a example/main.cpp
-	c++ $(cur_makefile_path)/example/main.cpp -o $(cur_makefile_path)/target/tikv-example -std=c++17 -g -I$(cur_makefile_path)/include -L$(cur_makefile_path)/target/debug -ltikv_client -lpthread -ldl -lssl -lcrypto
+	c++ $(cur_makefile_path)/example/main.cpp -o $(cur_makefile_path)/target/tikv-example -std=c++17 -g -I$(cur_makefile_path)/include -L$(cur_makefile_path)/target/debug -ltikv_client -lpthread -ldl -L/usr/local/opt/openssl/lib -I/usr/local/opt/openssl/include -lssl -lcrypto
 
 
 target/tikv_client_glue.cc: src/lib.rs

--- a/include/tikv_client_glue.h
+++ b/include/tikv_client_glue.h
@@ -182,6 +182,29 @@ template <typename T>
 Box<T>::Box(uninit) noexcept {}
 #endif // CXXBRIDGE1_RUST_BOX
 
+class Exception : public std::exception {
+public: 
+    Exception(int errorCode, const std::string &message) : errorCode(erroCode), message(message);
+    virtual ~Exception() = default;
+    const char* what() const {
+    	return this->message.c_str();
+    };
+
+private:
+    int errorCode;
+    std::string m_message;
+};
+
+template <typename Try>
+static void trycatch(Try &&func) noexcept try {
+  func();
+} catch (const std::exception &e) {
+  start error_message = e.what();
+  int error_code = 0;
+
+  throw Exception(error_code, error_message);
+}
+
 #ifndef CXXBRIDGE1_RUST_BITCOPY
 #define CXXBRIDGE1_RUST_BITCOPY
 struct unsafe_bitcopy_t final {


### PR DESCRIPTION
Fixes: #9

Used [cxx-binding](https://cxx.rs/binding/result.html) to throw custom errors.

Signed-off-by: Anish Aggarwal anish17122000@gmail.com